### PR TITLE
fix: Threads logo icon and link to our account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",
-        "react-icons": "^4.3.1",
+        "react-icons": "^4.12.0",
         "react-virtuoso": "^2.7.1",
         "react-youtube": "^7.13.1"
       },
@@ -5876,9 +5876,10 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }
@@ -11735,9 +11736,9 @@
       }
     },
     "react-icons": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
-      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
-    "react-icons": "^4.3.1",
+    "react-icons": "^4.12.0",
     "react-virtuoso": "^2.7.1",
     "react-youtube": "^7.13.1"
   },

--- a/src/layout/common/Footer.jsx
+++ b/src/layout/common/Footer.jsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { Box, Spacer, Stack, Image } from '@chakra-ui/react';
 
 import { FaFacebookSquare, FaYoutube, FaInstagram } from 'react-icons/fa';
-/* import { FaThreads } from 'react-icons/fa6'; */
+import { FaThreads } from 'react-icons/fa6';
 
 const Wrapper = styled.footer`
   display: flex;
@@ -48,11 +48,11 @@ const Footer = () => {
         <a href="https://www.instagram.com/tueeit_0501" target="_blank" rel="noopener noreferrer">
           <FaInstagram />
         </a>
-        {/*
-          <a href="https://www.threads.com/@tueeit_0501" target="_blank" rel="noopener noreferrer">
-            <FaThreads />
-          </a>
-        */}
+
+        <a href="https://www.threads.com/@tueeit_0501" target="_blank" rel="noopener noreferrer">
+          <FaThreads />
+        </a>
+
       </Stack>
     </Wrapper>
   );


### PR DESCRIPTION
- Upgrade react-icons to 4.12 for Threads platform logo
- Uncomment the part of threads icon importing and implementation
<img width="936" height="740" alt="Snapshot for threads logo" src="https://github.com/user-attachments/assets/385f956c-2ede-4ccf-bc38-442f3600f059" />
